### PR TITLE
remove deprecation flags

### DIFF
--- a/db-connection.js
+++ b/db-connection.js
@@ -2,11 +2,7 @@ const mongoose = require('mongoose')
 
 const connectDB = async() => {
     try {
-        const conn = await mongoose.connect(process.env.MONGO_URI, {
-            useNewUrlParser: true,
-            useUnifiedTopology: true,
-            useFindAndModify: false
-        })
+        const conn = await mongoose.connect(process.env.MONGO_URI)
         
         console.log(`MongoDB Connected: ${conn.connection.host}`)
     } catch (err) {


### PR DESCRIPTION
Removes flags in db connection string to fully upgrade from mongoose v5 to v6.

https://mongoosejs.com/docs/5.x/docs/deprecations.html